### PR TITLE
Compatibility with Puzzle Toolbars add-on in Firefox

### DIFF
--- a/firefox/chrome/content/browser.css
+++ b/firefox/chrome/content/browser.css
@@ -2,7 +2,9 @@
  * Copyright (C) 2008 by Steve Krulewitz <skrulx@gmail.com>
  * Licensed under GPLv2 or later, see file LICENSE in the xpi for details.
  */
-.tbb-scripts-available .toolbarbutton-icon {
+.tbb-scripts-available .toolbarbutton-icon,
+/* Icons in a Puzzle Toolbar shouldn't have a background, so set the background on the button itself. */
+.puzzleBars-bar .tbb-scripts-available {
   background: linear-gradient(top, #f2825b 0%, #e55b2b 50%, #f07146 100%);
   background: -moz-linear-gradient(top, #f2825b 0%, #e55b2b 50%, #f07146 100%);
 }

--- a/firefox/chrome/content/browser.js
+++ b/firefox/chrome/content/browser.js
@@ -91,8 +91,18 @@ var GreasefireController = {
     case "load":
       window.addEventListener("aftercustomization", this, false);
       gBrowser.addProgressListener(this);
+      CustomizableUI.addListener(this);
       // no break
     case "aftercustomization":
+      this._setupMenu();
+      break;
+    }
+  },
+
+  onWidgetAfterDOMChange: function(aNode) {
+    switch(aNode.id) {
+    case "greasemonkey-tbb":
+    case "scriptish-button":
       this._setupMenu();
       break;
     }


### PR DESCRIPTION
Puzzle Toolbars is restartless, which means its toolbars are created only after Greasefire initializes. So it needs to listen to when the button is placed in the window to properly set things up. This will be true for every toolbar created on-the-fly by any add-on BTW.

Also, Puzzle Toolbars sets its own button style which makes the background in the icon hardly noticeable, so I set it on the button in this case instead.
